### PR TITLE
feat: Add post body with form and JSON content types

### DIFF
--- a/http_tui/app.css
+++ b/http_tui/app.css
@@ -6,6 +6,14 @@
   width: 1fr;
 }
 
+#request-body-view {
+  height: 5;
+}
+
+#request-body-view.hidden {
+  display:none;
+}
+
 #go {
   width: 5;
 }


### PR DESCRIPTION
Added a request body to POST requests, allows you to send url encoded form data or JSON.

Additional types could be supported but at the moment Textual lacks a multiline text input.